### PR TITLE
Detect Cloud Run and Cloud Functions in isCloudEnv()

### DIFF
--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -2,5 +2,9 @@
 export const isTTY = process.stdout.isTTY || process.env.NODE_ENV === 'test';
 
 export function isCloudEnv() {
-  return !!process.env.KUBERNETES_SERVICE_HOST;
+  return !!(
+    process.env.KUBERNETES_SERVICE_HOST || // GKE
+    process.env.K_SERVICE || // Cloud Run (services and jobs)
+    process.env.FUNCTION_TARGET // Cloud Functions / Cloud Run Functions (gen 2)
+  );
 }


### PR DESCRIPTION
`isCloudEnv()` only checks `KUBERNETES_SERVICE_HOST`, so apps on Cloud Run or Cloud Functions don't auto-init the Google Cloud logger. Their logs come through Cloud Logging as `textPayload` rather than `jsonPayload`, which breaks log-based metrics and queries on `jsonPayload.*` fields.

This adds checks for two more documented env vars:

- `K_SERVICE` - set by Cloud Run, per its [container runtime contract](https://cloud.google.com/run/docs/container-contract#env-vars)
- `FUNCTION_TARGET` - set by Cloud Functions and Cloud Run Functions (gen 2)

### Why not the metadata server

Google's own SDKs and OpenTelemetry's [GCP resource detector](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/resource-detector-gcp) check env vars first, then fall back to the [metadata server](https://cloud.google.com/compute/docs/metadata/overview) at `metadata.google.internal`. That's more thorough - the metadata server is reachable from every GCP runtime via a fast link-local path (host hypervisor on GCE, `gke-metadata-server` DaemonSet on GKE with Workload Identity, native on Cloud Run / Functions).

I've kept this PR to env-var checks only, to avoid putting a network dependency in the logger. The three vars cover all current GCP serverless and managed runtimes by their documented contracts. A metadata-server fallback could follow in a separate PR if it's ever needed - e.g. for apps on bare GCE, which has no platform-specific env var.

### Tests

None - `isCloudEnv()` is a three-line `||` check, `env.js` has no existing tests, and a unit test here would mostly exercise the `||` operator. Existing 81 tests pass.